### PR TITLE
Add README and action plan

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,48 @@
+# Action Plan
+
+Below is a high-level checklist derived from `plan.md` to bootstrap the project.
+
+1. **Set up the Python environment**
+   - Create a virtual environment: `python -m venv ai-assist`
+   - Install core packages: `pip install --upgrade pip`
+
+2. **Install the local model runner**
+   - Install [Ollama](https://ollama.com) and pull a small model, e.g. `mistral:instruct`.
+
+3. **Install required Python packages**
+   - Examples: `autogen`, `crewai`, `langgraph`, `open-interpreter`, `chromadb`, `pyautogui`, `playwright`, `faster-whisper`, `pdfplumber`, `pynput`.
+   - Run `playwright install chromium` to enable browser automation.
+
+4. **Create the project skeleton**
+   - `ai_assist/`
+     - `main.py` – entrypoint
+     - `agent/` with `planner.py`, `memory.py`, and `tools/`
+     - `ui/` for tray or voice interfaces
+
+5. **Implement a few core tools**
+   - File operations (find, move, etc.)
+   - Basic system app launching
+   - Browser automation
+
+6. **Integrate with an agent framework**
+   - Use AutoGen or an alternative to plan tasks and call your tools.
+
+7. **Add optional extras**
+   - Voice or hotkey listener for quick commands
+   - Memory storage with ChromaDB
+
+8. **Guardrails**
+   - Allow‑lists for destructive actions
+   - Step counter to avoid infinite loops
+
+9. **Smoke tests**
+   - Organize screenshots
+   - Summarize a PDF
+   - Launch a desktop app and control it
+
+10. **Future work**
+   - GUI (Electron or Tauri)
+   - Schedulers or IoT hooks
+   - Fine tuning small models with your data
+
+Refer to `plan.md` for detailed explanations and rationale behind each step.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# BorisAI
+
+This repository contains notes for building **Local Lindy** – a fully local AI assistant that can automate tasks on your machine. The plan outlines how to run a small language model locally, integrate it with Python tools, and interact with the operating system.
+
+The project is still in the planning stage. See `plan.md` for the long-form design document and `ACTION_PLAN.md` for a concise checklist of next steps.


### PR DESCRIPTION
## Summary
- add a project README describing BorisAI
- include `ACTION_PLAN.md` with a condensed checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d27ffac2c8320b125938d712ee0bc

## Summary by Sourcery

Add initial project documentation by introducing a README and a high-level action plan checklist.

Documentation:
- Add README.md to outline BorisAI’s purpose and reference design documents
- Add ACTION_PLAN.md with a concise checklist to bootstrap project setup and development