### PR TITLE
Implement local LLM integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,48 @@
+# Action Plan
+
+Below is a high-level checklist derived from `plan.md` to bootstrap the project.
+
+1. **Set up the Python environment**
+   - Create a virtual environment: `python -m venv ai-assist`
+   - Install core packages: `pip install --upgrade pip`
+
+2. **Install the local model runner**
+   - Install [Ollama](https://ollama.com) and pull a small model, e.g. `mistral:instruct`.
+
+3. **Install required Python packages**
+   - Examples: `autogen`, `crewai`, `langgraph`, `open-interpreter`, `chromadb`, `pyautogui`, `playwright`, `faster-whisper`, `pdfplumber`, `pynput`.
+   - Run `playwright install chromium` to enable browser automation.
+
+4. **Create the project skeleton**
+   - `ai_assist/`
+     - `main.py` – entrypoint
+     - `agent/` with `planner.py`, `memory.py`, and `tools/`
+     - `ui/` for tray or voice interfaces
+
+5. **Implement a few core tools**
+   - File operations (find, move, etc.)
+   - Basic system app launching
+   - Browser automation
+
+6. **Integrate with an agent framework**
+   - Use AutoGen or an alternative to plan tasks and call your tools.
+
+7. **Add optional extras**
+   - Voice or hotkey listener for quick commands
+   - Memory storage with ChromaDB
+
+8. **Guardrails**
+   - Allow‑lists for destructive actions
+   - Step counter to avoid infinite loops
+
+9. **Smoke tests**
+   - Organize screenshots
+   - Summarize a PDF
+   - Launch a desktop app and control it
+
+10. **Future work**
+   - GUI (Electron or Tauri)
+   - Schedulers or IoT hooks
+   - Fine tuning small models with your data
+
+Refer to `plan.md` for detailed explanations and rationale behind each step.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# BorisAI
+
+This repository contains notes for building **Local Lindy** – a fully local AI assistant that can automate tasks on your machine. The plan outlines how to run a small language model locally, integrate it with Python tools, and interact with the operating system.
+
+The project is still in the planning stage. See `plan.md` for the long-form design document and `ACTION_PLAN.md` for a concise checklist of next steps.
+
+## Quick start
+
+After installing [Ollama](https://ollama.com) and pulling a model, you can try the CLI:
+
+```bash
+python -m ai_assist plan "organize my screenshots"
+```
+
+Or enter a chat session:
+
+```bash
+python -m ai_assist chat
+```

--- a/ai_assist/__init__.py
+++ b/ai_assist/__init__.py
@@ -1,0 +1,5 @@
+"""BorisAI package."""
+
+from .main import main, cli
+
+__all__ = ["main", "cli"]

--- a/ai_assist/agent/__init__.py
+++ b/ai_assist/agent/__init__.py
@@ -1,0 +1,6 @@
+"""Agent subpackage."""
+
+from .planner import plan_task
+from .llm import generate
+
+__all__ = ["plan_task", "generate"]

--- a/ai_assist/agent/llm.py
+++ b/ai_assist/agent/llm.py
@@ -1,0 +1,12 @@
+"""Basic LLM interface for BorisAI using the official Ollama client."""
+
+import ollama
+
+
+def generate(prompt: str, model: str = "mistral:instruct") -> str:
+    """Return a completion from the local Ollama server."""
+    try:
+        resp = ollama.generate(model=model, prompt=prompt, stream=False)
+        return resp["response"] if isinstance(resp, dict) else resp.response
+    except Exception as exc:  # network errors or missing server
+        raise RuntimeError(f"LLM request failed: {exc}") from exc

--- a/ai_assist/agent/planner.py
+++ b/ai_assist/agent/planner.py
@@ -1,0 +1,21 @@
+"""Simple task planner."""
+
+from typing import List
+
+from .llm import generate
+
+
+def plan_task(prompt: str, *, model: str = "mistral:instruct") -> List[str]:
+    """Return a list of steps for the given prompt using the local LLM."""
+    response = generate(
+        f"Create a short numbered list of steps to accomplish: {prompt}",
+        model=model,
+    )
+    steps = []
+    for line in response.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        line = line.lstrip("-0123456789. ")
+        steps.append(line)
+    return steps

--- a/ai_assist/main.py
+++ b/ai_assist/main.py
@@ -1,0 +1,44 @@
+"""Main entrypoint for BorisAI."""
+
+from .agent.planner import plan_task
+from .agent.llm import generate
+
+
+def cli(argv: list[str] | None = None) -> None:
+    """Command-line interface for BorisAI."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="BorisAI")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_plan = sub.add_parser("plan", help="Create a numbered plan for a prompt")
+    p_plan.add_argument("prompt")
+    p_plan.add_argument("--model", default="mistral:instruct")
+
+    p_chat = sub.add_parser("chat", help="Chat with the local model")
+    p_chat.add_argument("--model", default="mistral:instruct")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "plan":
+        steps = plan_task(args.prompt, model=args.model)
+        for step in steps:
+            print(f"- {step}")
+    elif args.cmd == "chat":
+        print("Type 'exit' to quit.")
+        while True:
+            try:
+                prompt = input("> ")
+            except EOFError:
+                break
+            if prompt.strip().lower() in {"exit", "quit"}:
+                break
+            print(generate(prompt, model=args.model).strip())
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_assist/memory.py
+++ b/ai_assist/memory.py
@@ -1,0 +1,14 @@
+"""Simple in-memory storage placeholder."""
+
+
+class Memory:
+    """Store conversation history for now."""
+
+    def __init__(self):
+        self._messages = []
+
+    def add(self, message: str) -> None:
+        self._messages.append(message)
+
+    def get_all(self):
+        return list(self._messages)

--- a/ai_assist/tools/__init__.py
+++ b/ai_assist/tools/__init__.py
@@ -1,0 +1,16 @@
+"""Tool utilities for BorisAI."""
+
+from .files import find_latest, move_to
+
+
+def list_files(directory: str):
+    """Return a list of filenames for *directory*."""
+    import os
+    return os.listdir(directory)
+
+
+__all__ = [
+    "list_files",
+    "find_latest",
+    "move_to",
+]

--- a/ai_assist/tools/files.py
+++ b/ai_assist/tools/files.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def find_latest(pattern: str, root: str = str(Path.home())) -> str:
+    """Return the most recently modified file matching the pattern."""
+    files = sorted(Path(root).rglob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return str(files[0]) if files else ""
+
+
+def move_to(folder: str, path: str) -> str:
+    """Move the file at *path* into *folder* and return a message."""
+    src = Path(path)
+    dest = Path(folder) / src.name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dest)
+    return f"Moved {src} -> {dest}"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ai_assist.tools.files import find_latest, move_to
+
+
+def test_find_latest(tmp_path: Path):
+    # create two files with different modification times
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("1")
+    second.write_text("2")
+    # ensure different times
+    os.utime(first, (first.stat().st_atime, first.stat().st_mtime - 10))
+    assert find_latest("*.txt", root=str(tmp_path)) == str(second)
+
+
+def test_move_to(tmp_path: Path):
+    src = tmp_path / "source.txt"
+    dst_dir = tmp_path / "dst"
+    src.write_text("hello")
+    result = move_to(str(dst_dir), str(src))
+    assert (dst_dir / "source.txt").exists()
+    assert "Moved" in result

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ai_assist.agent.llm import generate
+
+
+def test_generate_success(monkeypatch):
+    class DummyResp:
+        def __init__(self, text):
+            self.response = text
+
+    def fake_generate(*args, **kwargs):
+        return DummyResp("step1\nstep2")
+
+    monkeypatch.setattr("ollama.generate", fake_generate)
+    result = generate("do something")
+    assert "step1" in result

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ai_assist.agent import plan_task
+
+
+def test_plan_task(monkeypatch):
+    def fake_generate(prompt, model="mistral:instruct"):
+        return "1. step1\n2. step2"
+
+    monkeypatch.setattr("ai_assist.agent.planner.generate", fake_generate)
+    steps = plan_task("test")
+    assert steps == ["step1", "step2"]


### PR DESCRIPTION
## Summary
- build a simple CLI with `plan` and `chat` commands
- call the local Ollama server using the official client
- extend the planner to accept a model name and parse steps
- document CLI usage in the README
- add tests for the planner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d27ffac2c8320b125938d712ee0bc